### PR TITLE
Support to japanese braces ｛｝

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var patternRegex = /((\{[^\}]+\}(?:\（|\()[^\}]+(?:\）|\)))+)/g;
-var kanjiRegex = /\{([^\}]+)\}(?:\（|\()([^\}]+)(?:\）|\))/g;
+var patternRegex = /(((?:\{|\｛)[^\}\｝]+(?:\}|\｝)(?:\（|\()[^\}\｝]+(?:\）|\)))+)/g;
+var kanjiRegex = /(?:\{|\｛)([^\}\｝]+)(?:\}|\｝)(?:\（|\()([^\}\｝]+)(?:\）|\))/g;
 
 var KanjiExtension = function(converter) {
   return [

--- a/test/test-kanji-extension.js
+++ b/test/test-kanji-extension.js
@@ -23,6 +23,24 @@ describe('Kanji Showdown Extension', function() {
     assert.equal(html, "<p><ruby>私<rt>わたし</rt></ruby>はジョーと<ruby>申<rt>もう</rt></ruby>します。</p>");
   });
 
+  it('should be able to handle multi-byte japanese braces', function () {
+    var html = showdown.makeHtml("｛私｝(わたし)はジョーと｛申｝(もう)します。");
+
+    assert.equal(html, "<p><ruby>私<rt>わたし</rt></ruby>はジョーと<ruby>申<rt>もう</rt></ruby>します。</p>");
+  });
+
+  it('should be able to handle a mix of utf-8 and japanese parens and braces', function () {
+    var html = showdown.makeHtml("{私｝(わたし)はジョーと｛申}(もう）します。");
+
+    assert.equal(html, "<p><ruby>私<rt>わたし</rt></ruby>はジョーと<ruby>申<rt>もう</rt></ruby>します。</p>");
+  });
+
+  it('should be able to handle japanese parens and braces', function () {
+    var html = showdown.makeHtml("｛私｝（わたし）はジョーと｛申｝（もう）します。");
+
+    assert.equal(html, "<p><ruby>私<rt>わたし</rt></ruby>はジョーと<ruby>申<rt>もう</rt></ruby>します。</p>");
+  });
+
   it('should convert kanji while not interfering with normal markdown accents', function () {
     var html = showdown.makeHtml("**これは**ジョーの{記}(き){事}(じ)です");
 


### PR DESCRIPTION
Hello @joeellis!

I took the liberty of changing your regex to accept multibyte Japanese braces.

```
~/showdown-kanji feat_multibyte-japanese-braces 14s
❯ find ./test -name 'test-*' | ./node_modules/mocha/bin/mocha
  Kanji Showdown Extension
    ✓ should convert marked kanji into furigana ruby tags
    ✓ should be able to handle multi-byte japanese parentheses
    ✓ should be able to handle a mix of utf-8 and japanese parens
    ✓ should be able to handle multi-byte japanese braces
    ✓ should be able to handle a mix of utf-8 and japanese parens and braces
    ✓ should be able to handle japanese parens and braces
    ✓ should convert kanji while not interfering with normal markdown accents

  7 passing (21ms)
```

I did some testing and looks like it's valid, but it would be great if you could validate the changes and check if it makes sense :)

Thanks in advance!